### PR TITLE
add a names table

### DIFF
--- a/src/__tests__/Interpreter.test.ts
+++ b/src/__tests__/Interpreter.test.ts
@@ -29,7 +29,7 @@ test('Interpreter', async () => {
         .map(([, decodedTx]) => decodedTx)
 
     for (const decodedTx of filteredDecodedTxes) {
-        expect(interpreter.interpretSingleTx(decodedTx!)).toMatchSnapshot()
+        expect(await interpreter.interpretSingleTx(decodedTx!)).toMatchSnapshot()
     }
     await db.closeConnection()
 }, 200000)

--- a/src/core/Augmenter.ts
+++ b/src/core/Augmenter.ts
@@ -63,9 +63,6 @@ export class Augmenter {
     rawTxDataArr!: RawTxData[]
     decodedArr!: DecodedTx[]
 
-    covalentData?: CovalentTxData
-    covalentDataArr: CovalentTxData[] = []
-
     fnSigCache: Record<string, string> = {}
     ensCache: Record<string, string> = {}
 
@@ -161,21 +158,6 @@ export class Augmenter {
         const transformedAugmentedData = Augmenter.augmentENSNames(transformedData, ensMap)
 
         return transformedAugmentedData
-    }
-
-    // TODO need to get it from contract JSON, ABI, and/or TinTin too, instead of Covalent
-    private augmentOfficialContractNames() {
-        if (this.covalentDataArr.length) {
-            this.covalentDataArr.forEach((covalentData, index) => {
-                this.decodedArr[index].officialContractName = covalentData.to_address_label || null
-            })
-        }
-    }
-
-    private augmentTimestampWithCovalent() {
-        this.covalentDataArr.forEach((covalentData, index) => {
-            this.decodedArr[index].timestamp = Number(covalentData.block_signed_at)
-        })
     }
 
     static augmentTraceLogs(interactionsWithoutNativeTransfers: Interaction[], traceLogs: TraceLog[]): Interaction[] {
@@ -452,7 +434,7 @@ export class Augmenter {
         const contractDataMap: Record<string, ContractData> = {}
         const filteredABIs = filterABIMap(contractToAbiMap)
 
-        const addresses = getKeys(contractToAbiMap)
+        const addresses = getKeys(contractToAbiMap).map((address) => AddressZ.parse(address))
 
         const contractDataMapFromDB = await this.db.getManyContractDataMap(addresses)
 

--- a/src/core/Interpreter.ts
+++ b/src/core/Interpreter.ts
@@ -15,6 +15,7 @@ import { Chain } from 'interfaces/utils'
 import { AddressZ } from 'interfaces/utils'
 
 import { fillDescriptionTemplate, getNativeTokenValueEvents, shortenNamesInString } from 'utils'
+import { DatabaseInterface, NullDatabaseInterface } from 'utils/DatabaseInterface'
 
 // Despite most contracts using Open Zeppelin's standard naming convention of "to, from, value", not all do. Most notably, DAI and WETH use "src, dst, wad". These are used rename the keys to match the standard (both for generic and contract-specific interpretations).
 const toKeys = ['to', '_to', 'dst']
@@ -54,10 +55,12 @@ class Interpreter {
     // fallbackInterpreters: Array<Inspector> = []
     userAddress: string | null
     chain: Chain
+    db: DatabaseInterface
 
-    constructor(chain: Chain, userAddress: string | null = null) {
+    constructor(chain: Chain, userAddress: string | null = null, db: DatabaseInterface | null = null) {
         this.chain = chain
         this.userAddress = (userAddress && AddressZ.parse(userAddress)) || null
+        this.db = db || new NullDatabaseInterface()
 
         for (const [address, map] of Object.entries(contractInterpreters)) {
             this.contractSpecificInterpreters[address] = map as InterpreterMap
@@ -72,23 +75,23 @@ class Interpreter {
         this.chain = chain
     }
 
-    public interpret(decodedDataArr: DecodedTx[]): Interpretation[] {
+    async interpret(decodedDataArr: DecodedTx[]): Promise<Interpretation[]> {
         const interpretations: Interpretation[] = []
 
         for (let i = 0; i < decodedDataArr.length; i++) {
             const decodedData = decodedDataArr[i]
-            const interpretation = this.interpretSingleTx(decodedData)
+            const interpretation = await this.interpretSingleTx(decodedData)
             interpretations.push(interpretation)
         }
 
         return interpretations
     }
 
-    public interpretSingleTx(
+    async interpretSingleTx(
         decodedData: DecodedTx,
         userAddressFromInput: string | null = null,
         userNameFromInput: string | null = null,
-    ): Interpretation {
+    ): Promise<Interpretation> {
         // Prep data coming in from 'decodedData'
         const {
             methodCall: { name: methodName },
@@ -109,14 +112,20 @@ class Interpreter {
 
         const userAddress = parsedAddress.success ? parsedAddress.data : this.userAddress || fromAddress
 
-        let userName = userNameFromInput || userAddress.substring(0, 6)
+        let userName = null
 
         if (fromAddress === userAddress) {
-            userName = decodedData.fromENS || userName
+            userName = decodedData.fromENS
         }
         if (toAddress === userAddress) {
-            userName = decodedData.toENS || userName
+            userName = decodedData.toENS
         }
+
+        userName =
+            userName ||
+            userNameFromInput ||
+            (await this.db.getEntityByAddress(userAddress)) ||
+            userAddress.substring(0, 6)
 
         // TODO generalize this so it'll get any ENS (ex: _operatorENS)
 
@@ -140,6 +149,15 @@ class Interpreter {
             counterpartyName: null,
             timestamp,
         }
+
+        let fromName = await this.db.getEntityByAddress(fromAddress)
+        let toName = await this.db.getEntityByAddress(toAddress || '')
+
+        if (fromName) interpretation.fromName = fromName
+        if (toName) interpretation.toName = toName
+
+        fromName = fromName || fromAddress.substring(0, 6)
+        toName = toName || (toAddress || '').substring(0, 6)
 
         if (interpretation.reverted) {
             interpretation.exampleDescription = 'transaction reverted'
@@ -167,7 +185,8 @@ class Interpreter {
             )
         } else if (decodedData.txType === TxType.TRANSFER) {
             // Generic transfer
-            interpretGenericTransfer(decodedData, interpretation)
+
+            interpretGenericTransfer(decodedData, interpretation, fromName, toName)
         } else if (interpretationMapping && methodSpecificMapping && methodName && toAddress) {
             // Contract-specific interpretation
 

--- a/src/core/genericInterpreters/transfer.ts
+++ b/src/core/genericInterpreters/transfer.ts
@@ -5,7 +5,12 @@ function isSafeReceivedEvent(event: InteractionEvent, userAddress: string) {
     return event.eventName === 'SafeReceived' && event.params.sender === userAddress
 }
 
-function interpretGenericTransfer(decodedData: DecodedTx, interpretation: Interpretation) {
+function interpretGenericTransfer(
+    decodedData: DecodedTx,
+    interpretation: Interpretation,
+    fromName: string,
+    toName: string,
+) {
     const { fromAddress, toAddress, interactions } = decodedData
     const { userAddress, nativeValueSent, chainSymbol, userName } = interpretation
     const sending = fromAddress === userAddress
@@ -21,11 +26,11 @@ function interpretGenericTransfer(decodedData: DecodedTx, interpretation: Interp
     let counterpartyName = null
     if (isSafeReceived && sending) {
         // TODO confirm safeReceived is decoded
-        counterpartyName = `Gnosis Safe ${decodedData.toENS || toAddress?.slice(0, 6)}`
+        counterpartyName = `Gnosis Safe ${decodedData.toENS || toName}`
     } else if (sending) {
-        counterpartyName = decodedData.toENS || toAddress?.slice(0, 6)
+        counterpartyName = decodedData.toENS || toName
     } else {
-        counterpartyName = decodedData.fromENS || fromAddress.slice(0, 6)
+        counterpartyName = decodedData.fromENS || fromName
     }
 
     const exampleDescription = `${userName} ${action} ${nativeValueSent} ${chainSymbol} ${direction} ${counterpartyName}`

--- a/src/interfaces/decoded.ts
+++ b/src/interfaces/decoded.ts
@@ -44,6 +44,13 @@ export const enum ContractType {
     OTHER = 'OTHER',
 }
 
+export type AddressNameData = {
+    address: string
+    name: string
+    entity: string
+    ancestorAddress: string
+}
+
 //  100% objective additional info (data taken from a blockchain)
 export type DecodedTx = {
     /** The transaction's unique hash */

--- a/src/interfaces/interpreted.ts
+++ b/src/interfaces/interpreted.ts
@@ -12,6 +12,8 @@ export type Interpretation = {
     userAddress: string
     contractName: string | null
     contractAddress: string | null
+    fromName?: string
+    toName?: string
     action: Action
     exampleDescription: string
     tokensSent: Token[] // usually just one token

--- a/src/utils/DatabaseInterface.ts
+++ b/src/utils/DatabaseInterface.ts
@@ -31,6 +31,8 @@ export abstract class DatabaseInterface {
     // abstract addOrUpdateDecodedTx(decodedData: DecodedTx): Promise<void>
     abstract addOrUpdateManyDecodedTx(decodedDataArr: DecodedTx[]): Promise<void>
 
+    abstract getEntityByAddress(address: string): Promise<string | null>
+
     // abstract addOrUpdateInterpretedData(interpretedData: Interpretation): Promise<void>
     // abstract addOrUpdateManyInterpretedData(interpretedDataArr: Interpretation[]): Promise<void>
 
@@ -100,6 +102,10 @@ export class NullDatabaseInterface extends DatabaseInterface {
     }
 
     async getFirstABIRowForHexSignature(hexSignature: string): Promise<ABI_Row | null> {
+        return Promise.resolve(null)
+    }
+
+    async getEntityByAddress(address: string): Promise<string | null> {
         return Promise.resolve(null)
     }
 

--- a/src/utils/mongoose/index.ts
+++ b/src/utils/mongoose/index.ts
@@ -1,10 +1,12 @@
+import { AddressNameModel } from './models/addressName'
 import { ContractModel } from './models/contract'
 import { DecodedTxModel } from './models/decodedTx'
 import { BulkResult } from 'mongodb'
 import { connect, connection, Document, Types } from 'mongoose'
 
 import { ABI_Event, ABI_EventZ, ABI_ItemUnfiltered, ABI_Row, ABI_RowZ, ABI_Type } from 'interfaces/abi'
-import { ContractData, DecodedTx } from 'interfaces/decoded'
+import { AddressNameData, ContractData, DecodedTx } from 'interfaces/decoded'
+import { AddressZ } from 'interfaces/utils'
 
 import { DatabaseInterface } from 'utils/DatabaseInterface'
 import { logInfo } from 'utils/logging'
@@ -63,28 +65,6 @@ export class MongooseDatabaseInterface extends DatabaseInterface {
             console.log('contract mongoose error')
             console.log(e)
         }
-
-        // const chunks = collect(contractDataArr).chunk(500).toArray() as ContractData[][]
-
-        // for (const chunkId in chunks) {
-        //     const chunk = chunks[chunkId]
-
-        //     try {
-        //         // only way to do bulk upsert
-        //         const { result } = await ContractModel.bulkWrite(
-        //             chunk.map((contract) => ({
-        //                 updateOne: {
-        //                     filter: { address: contract.address },
-        //                     update: contract,
-        //                     upsert: true,
-        //                 },
-        //             })),
-        //         )
-        //     } catch (e) {
-        //         console.log('contract mongoose error')
-        //         console.log(e)
-        //     }
-        // }
     }
 
     async addOrUpdateManyABI(abiArr: ABI_Row[]): Promise<BulkResult> {
@@ -192,5 +172,40 @@ export class MongooseDatabaseInterface extends DatabaseInterface {
 
     async closeConnection() {
         connection.close()
+    }
+
+    async getManyNameDataMap(addresses: string[]): Promise<Record<string, AddressNameData | null>> {
+        const nameMap: Record<string, AddressNameData | null> = {}
+        for (let i = 0; i < addresses.length; i++) {
+            nameMap[addresses[i]] = null
+        }
+
+        try {
+            const modelData = await AddressNameModel.find({ address: { $in: addresses } })
+            const data = modelData.map((model) => model.toObject())
+
+            for (let i = 0; i < addresses.length; i++) {
+                const address = addresses[i]
+                const addressNameData = data.find((nameData) => nameData.address === address)
+                nameMap[address] = addressNameData || null
+            }
+        } catch (e) {
+            console.log('get nameMap mongoose error')
+            console.log(e)
+            // return null
+        }
+        // return here instead of in the try, so that it still works if the db is down
+        return nameMap
+    }
+
+    async getEntityByAddress(address: string): Promise<string | null> {
+        try {
+            const modelData = await AddressNameModel.findOne({ address })
+            return modelData ? modelData.toObject().entity : null
+        } catch (e) {
+            console.log('get nameByAddress mongoose error')
+            console.log(e)
+            throw e
+        }
     }
 }

--- a/src/utils/mongoose/models/addressName.ts
+++ b/src/utils/mongoose/models/addressName.ts
@@ -1,0 +1,15 @@
+import { model, Model, models, Schema } from 'mongoose'
+
+import { AddressNameData } from 'interfaces/decoded'
+
+type AddressNameModelType = Model<AddressNameData>
+
+const AddressNameSchema = new Schema<AddressNameData, AddressNameModelType>({
+    address: { type: String, required: true, lowercase: true },
+    name: { type: String, required: false },
+    entity: { type: String, required: false },
+    ancestorAddress: { type: String, required: false, lowercase: true },
+}).index({ address: 1 }, { unique: true })
+
+export const AddressNameModel = (models.addressName ||
+    model<AddressNameData>('addressName', AddressNameSchema)) as AddressNameModelType

--- a/src/utils/mongoose/models/contract.ts
+++ b/src/utils/mongoose/models/contract.ts
@@ -5,7 +5,7 @@ import { ContractData } from 'interfaces/decoded'
 type ContractModelType = Model<ContractData>
 
 const ContractSchema = new Schema<ContractData, ContractModelType>({
-    address: { type: String, required: true },
+    address: { type: String, required: true, lowercase: true },
     type: { type: String, required: true }, // TODO: add the enum
     tokenName: { type: String, required: false },
     tokenSymbol: { type: String, required: false },


### PR DESCRIPTION
Added a table of address names to mongoose. Source: https://github.com/iraykhel/blockchain-address-database/blob/main/data/addresses.db

this checks if we have a name for the from/to address of a tx. If it's just an eth transfer, it'll use the name is the example description too.

For now, if there's a name for either the from/to address, it'll add a field in the interpreted object `fromName`, `toName`

I also lowercased all the address fields in the DB so we don't run into upper/lowercase issues