### PR TITLE
handle errors gracefully

### DIFF
--- a/src/core/DoubleSidedTxInterpreter.ts
+++ b/src/core/DoubleSidedTxInterpreter.ts
@@ -6,9 +6,8 @@ export function getActionForDoubleSidedTx(interpretation: Interpretation): Actio
     } else if (parseFloat(interpretation.nativeValueReceived) !== 0 && interpretation.tokensSent.length) {
         return Action.sold
     } else {
-        throw new Error(
-            `Invalid NFT sale: received ${interpretation.nativeValueReceived} ETH and ${interpretation.tokensReceived.length} tokens, sent ${interpretation.nativeValueSent} ETH and ${interpretation.tokensSent.length} tokens`,
-        )
+        console.log(`ERROR! Invalid NFT sale: received ${interpretation.nativeValueReceived} ETH and ${interpretation.tokensReceived.length} tokens, sent ${interpretation.nativeValueSent} ETH and ${interpretation.tokensSent.length} tokens`)
+        return Action.unknown
     }
 }
 
@@ -26,8 +25,7 @@ export function getNativeValueTransferredForDoubleSidedTx(interpretation: Interp
     ) {
         return interpretation.nativeValueReceived
     } else {
-        throw new Error(
-            `Invalid NFT sale: action: ${interpretation.actions[0]}, received ${interpretation.nativeValueReceived} ETH and ${interpretation.tokensReceived.length} tokens, sent ${interpretation.nativeValueSent} ETH and ${interpretation.tokensSent.length} tokens`,
-        )
+        console.log(`Invalid NFT sale: action: ${interpretation.actions[0]}, received ${interpretation.nativeValueReceived} ETH and ${interpretation.tokensReceived.length} tokens, sent ${interpretation.nativeValueSent} ETH and ${interpretation.tokensSent.length} tokens`)
+        return Action.unknown
     }
 }

--- a/src/core/MulticallTxInterpreter.ts
+++ b/src/core/MulticallTxInterpreter.ts
@@ -5,7 +5,8 @@ import ABIDecoder from 'utils/abi-decoder'
 
 const pruneTraceRecursive = (calls: TraceLog[]): TraceLog[] => {
     if (!calls.length) {
-        throw new Error("This shouldn't happen")
+        console.log("ERROR! Faulty structure of multicall subtraces")
+        return []
     }
     if (!calls[0].subtraces) {
         return calls
@@ -33,7 +34,8 @@ export async function decodeRawTxTrace(abiDecoder: ABIDecoder, txTrace: TraceLog
         callsToPrune.shift()
     }
     if (callsToPrune.length) {
-        throw new Error("This shouldn't happen")
+        console.log("ERROR! Faulty structure of multicall subtraces")
+        return new Promise((resolve) => resolve([]))
     }
     return Promise.all(
         secondLevelCalls.map((call) =>


### PR DESCRIPTION
Don't throw errors when interpreting bad double-sided and multicall transactions